### PR TITLE
A0-1535 Revert-smart-contracts-on-mainnet-branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,6 @@ dependencies = [
  "jsonrpsee",
  "libp2p 0.44.0",
  "log",
- "pallet-contracts-rpc",
  "pallet-staking",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
@@ -292,9 +291,6 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-contracts",
- "pallet-contracts-primitives",
- "pallet-contracts-rpc-runtime-api",
  "pallet-elections",
  "pallet-identity",
  "pallet-multisig",
@@ -4917,88 +4913,6 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-contracts"
-version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.28#5e8b6fa2130236497878e53c169e41f1f7871e6b"
-dependencies = [
- "bitflags",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "log",
- "pallet-contracts-primitives",
- "pallet-contracts-proc-macro",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "smallvec",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-sandbox",
- "sp-std",
- "wasm-instrument",
- "wasmi-validation",
-]
-
-[[package]]
-name = "pallet-contracts-primitives"
-version = "6.0.0"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.28#5e8b6fa2130236497878e53c169e41f1f7871e6b"
-dependencies = [
- "bitflags",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-contracts-proc-macro"
-version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.28#5e8b6fa2130236497878e53c169e41f1f7871e6b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pallet-contracts-rpc"
-version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.28#5e8b6fa2130236497878e53c169e41f1f7871e6b"
-dependencies = [
- "jsonrpsee",
- "pallet-contracts-primitives",
- "pallet-contracts-rpc-runtime-api",
- "parity-scale-codec",
- "serde",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-contracts-rpc-runtime-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/Cardinal-Cryptography/substrate.git?branch=aleph-v0.9.28#5e8b6fa2130236497878e53c169e41f1f7871e6b"
-dependencies = [
- "pallet-contracts-primitives",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-node"
-version = "0.8.0"
+version = "0.8.0-mainnet"
 dependencies = [
  "aleph-runtime",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-runtime"
-version = "0.8.0"
+version = "0.8.0-mainnet"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -65,7 +65,6 @@ sc-rpc-api = { git = "https://github.com/Cardinal-Cryptography/substrate.git", b
 sp-blockchain = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 sp-block-builder = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 substrate-frame-rpc-system = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
-pallet-contracts-rpc = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 pallet-transaction-payment-rpc = { git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 
 [build-dependencies]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-node"
-version = "0.8.0"
+version = "0.8.0-mainnet"
 authors = ["Cardinal Cryptography"]
 description = "Aleph node binary"
 edition = "2021"

--- a/bin/node/src/rpc.rs
+++ b/bin/node/src/rpc.rs
@@ -55,7 +55,7 @@ where
 
     module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
 
-    module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
+    module.merge(TransactionPayment::new(client).into_rpc())?;
 
     use crate::aleph_node_rpc::{AlephNode, AlephNodeApiServer};
     module.merge(AlephNode::new(import_justification_tx).into_rpc())?;

--- a/bin/node/src/rpc.rs
+++ b/bin/node/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use aleph_runtime::{opaque::Block, AccountId, Balance, BlockNumber, Hash, Index};
+use aleph_runtime::{opaque::Block, AccountId, Balance, Index};
 use finality_aleph::JustificationNotification;
 use futures::channel::mpsc;
 use jsonrpsee::RpcModule;
@@ -36,14 +36,12 @@ where
     C: ProvideRuntimeApi<Block>,
     C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
     C: Send + Sync + 'static,
-    C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
     B: BlockT,
 {
-    use pallet_contracts_rpc::{Contracts, ContractsApiServer};
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
 
@@ -58,8 +56,6 @@ where
     module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
 
     module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
-
-    module.merge(Contracts::new(client).into_rpc())?;
 
     use crate::aleph_node_rpc::{AlephNode, AlephNodeApiServer};
     module.merge(AlephNode::new(import_justification_tx).into_rpc())?;

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-runtime"
-version = "0.8.0"
+version = "0.8.0-mainnet"
 authors = ["Cardinal Cryptography"]
 edition = "2021"
 homepage = "https://alephzero.org"

--- a/bin/runtime/Cargo.toml
+++ b/bin/runtime/Cargo.toml
@@ -24,9 +24,6 @@ frame-try-runtime = { default-features = false, git = "https://github.com/Cardin
 pallet-aura = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 pallet-authorship = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 pallet-balances = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
-pallet-contracts = { git = "https://github.com/Cardinal-Cryptography/substrate", default-features = false, branch = "aleph-v0.9.28" }
-pallet-contracts-primitives = { git = "https://github.com/Cardinal-Cryptography/substrate", default-features = false, branch = "aleph-v0.9.28" }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/Cardinal-Cryptography/substrate", default-features = false, branch = "aleph-v0.9.28" }
 pallet-identity = { git = "https://github.com/Cardinal-Cryptography/substrate", default-features = false, branch = "aleph-v0.9.28" }
 pallet-randomness-collective-flip = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
 pallet-session = { default-features = false, git = "https://github.com/Cardinal-Cryptography/substrate.git", branch = "aleph-v0.9.28" }
@@ -105,9 +102,6 @@ std = [
     "pallet-transaction-payment-rpc-runtime-api/std",
     "frame-system-rpc-runtime-api/std",
     "primitives/std",
-    "pallet-contracts-primitives/std",
-    "pallet-contracts-rpc-runtime-api/std",
-    "pallet-contracts/std",
     "pallet-nomination-pools/std",
 ]
 short_session = ["primitives/short_session"]
@@ -115,7 +109,6 @@ try-runtime = [
     "frame-executive/try-runtime",
     "frame-try-runtime",
     "frame-system/try-runtime",
-    "pallet-contracts/try-runtime",
     "pallet-nomination-pools/try-runtime",
     "pallet-aleph/try-runtime",
     "pallet-aura/try-runtime",


### PR DESCRIPTION
This is a test PR to show a proposal for code change that removes `pallet-contract` from `aleph-node`. 